### PR TITLE
Allow Multiple Signals Same Model Different Constraints

### DIFF
--- a/email_signals/constraint_checker.py
+++ b/email_signals/constraint_checker.py
@@ -11,20 +11,19 @@ class ConstraintChecker:
     determines if it is able to raise a signal.
     """
 
-    def __init__(self, instance: Model, signal_kwargs: dict):
+    def __init__(
+        self, instance: Model, constraints: _t.List[Model], signal_kwargs: dict
+    ):
         """Initialise the checker with the instance and signal kwargs.
 
         Args:
             instance: The model instance on which a signal is to be raised.
+            constraints: The constraints for the model instance
             signal_kwargs: The kwargs retrieved from the signal handler.
         """
         self.instance = instance
         self.signal_kwargs = signal_kwargs
-        self.constraints = SignalConstraint.objects.filter(
-            signal=Signal.objects.get(
-                content_type=ContentType.objects.get_for_model(instance)
-            )
-        )
+        self.constraints = constraints
 
     def run_tests(self) -> bool:
         """Run all tests and return `True` if all tests pass."""

--- a/email_signals/signals.py
+++ b/email_signals/signals.py
@@ -17,7 +17,8 @@ def signal_callback(
     for model_signal in model_signals:
         if not model_signal.active:
             continue
-        if not ConstraintChecker(instance, kwargs).run_tests():
+        constraints = model_signal.constraints.all()
+        if not ConstraintChecker(instance, constraints, kwargs).run_tests():
             continue
 
         # When the program reaches this point, the constraint checker has

--- a/email_signals/tests/test_constraint_checker.py
+++ b/email_signals/tests/test_constraint_checker.py
@@ -14,7 +14,7 @@ class TestConstraintChecker(EmailSignalTestCase):
         signal.
         """
         self.create_signal(self.customer_rec)
-        constraint_checker = ConstraintChecker(self.customer_rec, {})
+        constraint_checker = ConstraintChecker(self.customer_rec, [], {})
         self.assertEqual(list(constraint_checker.constraints), [])
 
     def test_init_with_constraints(self):
@@ -29,7 +29,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="b",
         )
         signal_constraint.save()
-        constraint_checker = ConstraintChecker(self.customer_rec, {})
+        constraints = signal_rec.constraints.all()
+        constraint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {}
+        )
 
         self.assertEqual(
             list(constraint_checker.constraints), [signal_constraint]
@@ -58,7 +61,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="b",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_rec, {})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {}
+        )
 
         with self.assertRaises(ValueError):
             constaint_checker.get_param_1(constraint.param_1)
@@ -75,8 +81,9 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2=None,
         )
         constraint.save()
+        constraints = signal.constraints.all()
         constaint_checker = ConstraintChecker(
-            self.customer_rec, {"a": {"b": 1}}
+            self.customer_rec, constraints, {"a": {"b": 1}}
         )
 
         self.assertEqual(constaint_checker.get_param_1(constraint.param_1), 1)
@@ -96,7 +103,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2=None,
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_order_rec, {})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_order_rec, constraints, {}
+        )
 
         self.assertEqual(
             constaint_checker.get_param_1(constraint.param_1), "Test Name"
@@ -114,8 +124,9 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="a.b",
         )
         constraint.save()
+        constraints = signal.constraints.all()
         constaint_checker = ConstraintChecker(
-            self.customer_rec, {"a": {"b": 1}}
+            self.customer_rec, constraints, {"a": {"b": 1}}
         )
 
         self.assertEqual(constaint_checker.get_param_1(constraint.param_2), 1)
@@ -135,7 +146,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="customer.name",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_order_rec, {})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_order_rec, constraints, {}
+        )
 
         self.assertEqual(
             constaint_checker.get_param_2(constraint.param_2), "Test Name"
@@ -153,7 +167,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="b",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_rec, {})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {}
+        )
 
         self.assertEqual(
             constaint_checker.get_param_2(constraint.param_2), "b"
@@ -169,7 +186,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="1.1",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_rec, {"a": 1})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {"a": 1}
+        )
 
         self.assertEqual(constaint_checker.get_params(constraint), (1, 1.1))
 
@@ -183,7 +203,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="1.1",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_rec, {"a": 1.1})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {"a": 1.1}
+        )
 
         self.assertTrue(constaint_checker.run_tests())
 
@@ -197,7 +220,10 @@ class TestConstraintChecker(EmailSignalTestCase):
             param_2="1.1",
         )
         constraint.save()
-        constaint_checker = ConstraintChecker(self.customer_rec, {"a": 1})
+        constraints = signal.constraints.all()
+        constaint_checker = ConstraintChecker(
+            self.customer_rec, constraints, {"a": 1}
+        )
 
         self.assertFalse(constaint_checker.run_tests())
 


### PR DESCRIPTION
I found that when I had multiple signals for the same model with separate constraints that the following would error with
`email_signals.models.Signal.MultipleObjectsReturned: get() returned more than one Signal -- it returned 2!`
This section would look for the constraints for a signal looking for only one signal based on the instance.
```python
self.constraints = SignalConstraint.objects.filter(
    signal=Signal.objects.get(
        content_type=ContentType.objects.get_for_model(instance)
    )
)
```
I was able to fix this by using the signal callback that is already iterating through the model_signals and get the constraint list from that to use for testing the constraints.